### PR TITLE
Remove dependency on printf and friends in the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,9 @@ RANLIB = ranlib
 CXXFLAGS += -I. -I./include $(PLATFORM_CXXFLAGS) $(OPT) $(WARNINGFLAGS)
 COUNT_OBJECTS = $(COUNT_FILES:.cc=.o)
 TESTS = 
-DEV = demo
 
 # Targets
-all: libcount.a $(DEV)
+all: libcount.a
 
 .PHONY:
 check: $(TESTS)

--- a/include/count/hll_debug.h
+++ b/include/count/hll_debug.h
@@ -21,11 +21,8 @@
 
 extern "C" {
 
-// Print debug information about a context.
-void HLL_debug_print(FILE* file, HLL_CTX* ctx);
-
-// Run unit tests. Returns 0 on success, -1 otherwise. Logs errors to file.
-int HLL_test(FILE* file);
+// Run unit tests. Returns 0 on success, -1 otherwise. Logs errors to stderr.
+int HLL_test();
 
 }  // extern "C"
 


### PR DESCRIPTION
The HLL_test() function, which will soon be deprecated, used printf.  However, printf presents portability issues because formatters for unusual types (such uint64_t) are not standard across platforms. Rather than pepper the code with #ifdef's, changed the routine to use cerr instead.

Also, the default Make target now just builds the library, and won't build the demo.

The demo still won't compile on OSX.
