### PR TITLE
EMP_alpha() should use number of registers and not precision value in calculation.

### DIFF
--- a/count/empirical_data.cc
+++ b/count/empirical_data.cc
@@ -56,7 +56,7 @@ double EMP_alpha(int precision) {
     case 6:
       return 0.709;
     default:
-      return (0.7213 / (1.0 + (1.079 / static_cast<double>(precision))));
+      return (0.7213 / (1.0 + (1.079 / static_cast<double>(1 << precision))));
   }
 }
 


### PR DESCRIPTION
Per the original paper, the alpha calculation:

```
αm := 0.7213/(1 + 1.079/m) for m ≥ 128
```

Should use number of registers (m) in the denominator, not the precision value.  (The number of registers is 2 raised to the p.) The erroneous code used p instead of 1 << p.
